### PR TITLE
Prevent input and orientation zooming on iOS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,10 @@
   padding: 0;
 }
 
+html {
+  -webkit-text-size-adjust: 100%;
+}
+
 body {
   padding: 10px;
   font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, Courier, monospace;
@@ -61,7 +65,7 @@ summary {
 .editor,
 .snapshot {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
-  font-size: 15px;
+  font-size: 16px;
   color: #333;
   min-height: 6em;
   border: 1px solid #ccc;


### PR DESCRIPTION
Avoids zooming the viewport when focusing the editor input and when changing to landscape orientation.